### PR TITLE
Update site header - Issue #15

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,7 +1,6 @@
 <li class="active"><a href="#">Home</a></li>
 <li><a href="#projects">Projects</a></li>
 <li><a href="#meetup">Events</a></li>
-<li><a href="#contact">Contact</a></li>
 
 <!-- Read about Bootstrap dropdowns at http://twitter.github.com/bootstrap/javascript.html#dropdowns -->
 <li class="dropdown" id="menu1">
@@ -37,6 +36,11 @@
 
     <li class="divider"></li>
 
+    <li>
+      <a href="#contact">
+        <i class=icon-envelope icon-white></i>
+        Email Orur Brigade Captains</a>
+    </li>
     <li>
       <a href="{{ site.brigade.mailchimp }}">
         <i class=icon-envelope icon-white></i>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -39,7 +39,7 @@
     <li>
       <a href="#contact">
         <i class=icon-envelope icon-white></i>
-        Email Orur Brigade Captains</a>
+        Email Our Brigade Captains</a>
     </li>
     <li>
       <a href="{{ site.brigade.mailchimp }}">

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -10,29 +10,7 @@
   </a>
   <ul class="dropdown-menu">
 
-    <li>
-      <a href="{{ site.brigade.github }}">
-        <i class=icon-wrench icon-white></i>
-        Our Code on GitHub</a>
-    </li>
-
-    <li class="divider"></li>
-
-    <li>
-      <a href="{{ site.brigade.meetup-link }}">
-        <i class=icon-group icon-white></i>
-        Our Events on Meetup</a>
-    </li>
-    <li>
-      <a href="{{ site.brigade.facebook }}">
-        <i class=icon-facebook-sign icon-white></i>
-        Our Facebook Page</a>
-    </li>
-        <li>
-      <a href="{{ site.brigade.twitter }}">
-        <i class=icon-retweet icon-white></i>
-        Our Tweets</a>
-    </li>
+    {% include social-media-nav.html %}
 
     <li class="divider"></li>
 

--- a/_includes/social-media-nav.html
+++ b/_includes/social-media-nav.html
@@ -1,0 +1,10 @@
+<div class="social-media-nav">
+  <a href="http://www.meetup.com/friendlycode/">
+    <i class="icon-meetup icon-white"></i>
+    MeetUp</a>
+  <a href="https://www.facebook.com/friendlycodegr">
+    <i class="icon-facebook-sign icon-white"></i>
+    Facebook</a>
+  <a href="https://twitter.com/friendlycodegr" title="@friendlycodegr">Twitter</a>
+  <a href="https://github.com/friendlycode">GitHub</a>
+</div><!-- /.socia-media-nav -->

--- a/_includes/social-media-nav.html
+++ b/_includes/social-media-nav.html
@@ -1,10 +1,26 @@
-<div class="social-media-nav">
-  <a href="http://www.meetup.com/friendlycode/">
-    <i class="icon-meetup icon-white"></i>
-    MeetUp</a>
-  <a href="https://www.facebook.com/friendlycodegr">
-    <i class="icon-facebook-sign icon-white"></i>
-    Facebook</a>
-  <a href="https://twitter.com/friendlycodegr" title="@friendlycodegr">Twitter</a>
-  <a href="https://github.com/friendlycode">GitHub</a>
-</div><!-- /.socia-media-nav -->
+<li>
+  <a href="{{ site.brigade.github }}" title="Our Code on GitHub">
+    <i class="icon-github"></i>
+    <span>Our Code on GitHub</span>
+  </a>
+</li>
+
+<li class="divider social-menu-item"></li>
+<li class="social-menu-item">
+  <a href="{{ site.brigade.meetup-link }}" title="Our Events on Meetup">
+    <i class="icon-group"></i>
+    <span>Our Events on Meetup</span>
+  </a>
+</li>
+<li class="social-menu-item">
+  <a href="{{ site.brigade.facebook }}" title="Our Facebook Page">
+    <i class="icon-facebook icon-sign"></i>
+    <span>Our Facebook Page</span>
+  </a>
+</li>
+<li class="social-menu-item">
+  <a href="{{ site.brigade.twitter }}" title="Our Tweets">
+    <i class="icon-twitter"></i>
+    <span>Our Tweets</span>
+  </a>
+</li>

--- a/index.html
+++ b/index.html
@@ -47,6 +47,9 @@
                 {% include navbar.html %}
               </ul>
             </div><!--/.nav-collapse -->
+
+            {% include social-media-nav.html %}
+
           </div><!-- /.navbar-inner -->
         </div><!-- /.navbar -->
 

--- a/index.html
+++ b/index.html
@@ -48,7 +48,9 @@
               </ul>
             </div><!--/.nav-collapse -->
 
-            {% include social-media-nav.html %}
+              <ul class="nav social-media-nav">
+                {% include social-media-nav.html %}
+              </ul>
 
           </div><!-- /.navbar-inner -->
         </div><!-- /.navbar -->

--- a/style.css
+++ b/style.css
@@ -59,7 +59,36 @@
 
 
 
-    /* CUSTOMIZE THE NAVBAR
+    /* HEADER SOCIAL MEDIA ICONS
+    -------------------------------------------------- */
+    .navbar .social-media-nav {
+      float: right;
+      margin-right: 0;
+      display: none;
+    }
+
+    .navbar .social-media-nav > li > a {
+      padding: 15px;
+    }
+
+    @media (min-width: 980px) {
+      .navbar .social-media-nav {
+        display: block;
+      }
+      .dropdown-menu .social-menu-item {
+        display: none;
+      }
+    }
+
+    .social-media-nav a {
+      color: #fff;
+    }
+    .social-media-nav span {
+      display: none;
+    }
+
+
+    /* CAROUSEL
     -------------------------------------------------- */
 
     /* Carousel base class */


### PR DESCRIPTION
Addresses issue #15:
- take the "social media" links, turn them into icons-only and right-justify them in the black menu-bar
- combine "Contact" and "Connect"

I've hidden the social media links from the dropdown at "desktop" size because they're available as icons. At "mobile" I hide the icons and add the links back into the dropdown. I've left the GitHub link at all sizes because it seemed important for that to be easy to find.

![fc_social-nav](https://cloud.githubusercontent.com/assets/1661708/11901437/a7af8720-a579-11e5-9a68-a69a0e67cf9f.gif)
